### PR TITLE
Update pufferize to prepare the required compacted dbg pufferfish needs

### DIFF
--- a/scripts/pufferize.py
+++ b/scripts/pufferize.py
@@ -56,7 +56,7 @@ for header, ref in fasta_iter(references):
 
 # parse unitigs and split if necessary
 # ASSUMPTION: we might need to split a unitig multiple times
-# NOTE: the split exact position in unitig depends on whether the seen kmer is the first or last kmer in a reference string.
+# NOTE: the exact position of the split in unitig depends on whether the seen kmer is the first or last kmer in a reference string.
 # NOTE: unitigs are renumbered consecutively
 # NOTE: former unitigs links are discarded
 #output = open(unitigs+".pufferized.fa","w")

--- a/scripts/pufferize.py
+++ b/scripts/pufferize.py
@@ -38,45 +38,103 @@ def normalize(kmer):
     return kmer if kmer < revcomp(kmer) else revcomp(kmer)
 
 
-ref_kmers=set()
+#ref_kmers=set()
+# parse references
+#for header, ref in fasta_iter(references):
+#  for kmer in [ref[:k], ref[-k:]]:
+#        ref_kmers.add(normalize(kmer))
+#        print(kmer)
+
+# go through all reference strings and keep the starting and end kmers for each of them in the ref_skmers and ref_ekmers respectively.
+ref_skmers=set()
+ref_ekmers=set()
 # parse references
 for header, ref in fasta_iter(references):
-  for kmer in [ref[:k], ref[-k:]]:
-        ref_kmers.add(normalize(kmer))
+    ref_skmers.add(ref[:k])
+    ref_ekmers.add(ref[-k:])
+
 
 # parse unitigs and split if necessary
-# ASSUMPTION: we will never have to split a unitig twice, because really, what are the chances that a unitig spans an entire reference sequence?
+# ASSUMPTION: we might need to split a unitig multiple times
+# NOTE: the split exact position in unitig depends on whether the seen kmer is the first or last kmer in a reference string.
 # NOTE: unitigs are renumbered consecutively
 # NOTE: former unitigs links are discarded
-output = open(unitigs+".pufferized.fa","w")
-nb_unitigs=0
+#output = open(unitigs+".pufferized.fa","w")
+output = open(unitigs+".pufferized.gfa", "w")
+nb_unitigs=-1
 def save_unitig(header,seq):
     global output, p, nb_unitigs
-    if "L:" in header:
-        header = header.split("L:")[0] # strip links
-    assert(header.split(' ')[0].isdigit())
-    new_header = ">%d " % nb_unitigs + ' '.join(header.split(' ')[1:]) # renumber unitigs
-    output.write("%s\n%s\n" % (new_header, seq))
     nb_unitigs += 1
+    output.write("S\t%s\t%s\n" % (nb_unitigs, seq))
+    return(nb_unitigs)
 
+
+unitig_skmer = {}
+unitig_ekmer = {}
+
+def create_unitig(header, unitig):
+    global unitig_skmer, unitig_ekmer
+    if len(unitig) == k:
+        unitig = normalize(unitig)
+    unitig_id=save_unitig(header, unitig)
+    if normalize(unitig[:k]) in unitig_skmer or normalize(unitig[:k]) in unitig_ekmer:
+        exit("Error: Initial kmer is repeated.")
+    if normalize(unitig[-k:]) in unitig_skmer or normalize(unitig[-k:]) in unitig_ekmer:
+        exit("Error: Last kmer is repeated.")
+    unitig_ekmer[normalize(unitig[-k:])] = [unitig_id, len(unitig)]
+   
+print("Start parsing and spliting unitigs .. ")
 for header, unitig in fasta_iter(unitigs):
-    seq = unitig
-    already_split = False
-    for i in range(len(unitig)-k+1):
-        kmer = normalize(unitig[i:i+k])
-        if kmer in ref_kmers:
-            if already_split:
-                exit("Error: this dataset violates the assumption that a unitig only needs to be split once.")
-            if i > 0 and i < len(unitig)-k+1:
-                save_unitig(header,unitig[:i+k-1])
-                save_unitig(header,unitig[i:])
-                print("split",unitig,"at",i)
-                already_split = True
-    if not already_split:
-        save_unitig(header,unitig)
+    prev = 0
+    for i in range(0,len(unitig)-k+1):
+        kmer = unitig[i:i+k]       
+        # cut up until first kmer but not the kmer itself
+        if kmer in ref_skmers or revcomp(kmer) in ref_ekmers:
+            if i+k-1-prev >= k:
+                create_unitig(header, unitig[prev:i+k-1])
+                prev = i
+        # cut the unitig until the kmer, including it
+        if kmer in ref_ekmers or revcomp(kmer) in ref_skmers:
+            create_unitig(header, unitig[prev:i+k])
+            prev = i+1
+    #add the last and right most unitig:
+    if len(unitig)-prev >= k:
+        create_unitig(header, unitig[prev:])
+
+
+print("Start reconstructing the path .. ")
+pathCtr = 0
+for header, ref in fasta_iter(references):
+    output.write("\nP\t")
+    i = 0   
+    seq = ''
+    while (i < len(ref)-k+1):
+        kmer = ref[i:i+k]
+        normalizedkmer = normalize(kmer)        
+        unitigInfo = []
+        ori = "+"
+        if normalizedkmer in unitig_skmer and normalizedkmer in unitig_ekmer:
+            unitigInfo = unitig_skmer[normalizedkmer]
+            if kmer == normalizedkmer:
+                ori = "+"
+            else:
+                ori = "-"
+        elif normalizedkmer in unitig_skmer:
+            unitigInfo = unitig_skmer[normalizedkmer]
+            ori = "+"
+        elif normalizedkmer in unitig_ekmer:
+            unitigInfo = unitig_ekmer[normalizedkmer]
+            ori = "-"
+        else:
+            print(pathCtr, " paths reconstructed.")
+            exit("ERROR: kmer is not found in the start or end of a unitig \n{0}  ,  {1}".format(kmer, normalizedkmer))
+        output.write("%s%s," % (unitigInfo[0], ori))
+        #increase i by the total number of kmers in the current unitig
+        i += (unitigInfo[1]-k+1)    
+    pathCtr+=1
 
 output.close()
-print("done. result is in: %s.pufferized.fa" % unitigs)
+print("done. result is in: %s.pufferized.gfa" % unitigs)
 print("to update unitig links in the fasta header (necessary to get a GFA file), run:")
 print("mv %s.pufferized.fa %s" % (unitigs,unitigs))
 prefix = "[prefix]" if ("unitigs.fa" not in unitigs) else (unitigs.split(".unitigs.fa")[0]+".h5")


### PR DESCRIPTION
Hello,
I am one of the people in the combine-lab team developing "[pufferfish](https://github.com/COMBINE-lab/pufferfish)" under the supervision of @rob-p.

Thank you for writing the pufferize script to prepare the input we needed for indexing.
We incorporated the following changes to pufferize :
1. Allowing a unitig to have more than one split.
2. The index the split happens in a unitig depends on whether the kmer is the first or the last in the reference string. If it's the first, it should be joined with the second part of the split, otherwise, it should be the last kmer of the first part of the split.
3. Adding a section that goes over the path or reference list and rewriting the references as the sequence of unitig ids to the output "gfa" file.