### PR TITLE
version info from release archive, fix #47

### DIFF
--- a/src/bcalm_1.cpp
+++ b/src/bcalm_1.cpp
@@ -81,9 +81,11 @@ struct Functor  {  void operator ()  (bcalm_1 *bcalm)
 
 void bcalm_1::execute (){
 
+    std::cout << "BCALM 2, version " << VERSION; 
 #ifdef GIT_SHA1
-    std::cout << "BCALM 2, version " << VERSION << ", git commit " << GIT_SHA1 << std::endl;
+    std::cout << ", git commit " << GIT_SHA1;
 #endif
+    std::cout << std::endl;
 
 
     /** we get the kmer size chosen by the end user. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,14 +25,16 @@
 
 int main (int argc, char* argv[])
 {
-	
+
+
+     if(argc > 1 && (   strcmp(argv[1],STR_VERSION)==0 || strcmp(argv[1],"-v")==0    )     ){
+        std::cout << "BCALM 2, version " << VERSION;
 #ifdef GIT_SHA1
-	if(argc > 1 && (   strcmp(argv[1],STR_VERSION)==0 || strcmp(argv[1],"-v")==0    )     ){
-        std::cout << "BCALM 2, version " << VERSION << ", git commit " << GIT_SHA1 << std::endl;
-     	std::cout << "Using gatb-core version "<< System::info().getVersion() << std::endl;
+        std::cout << ", git commit " << GIT_SHA1;
+#endif
+     	std::cout << std::endl << "Using gatb-core version "<< System::info().getVersion() << std::endl;
 		return EXIT_SUCCESS;
 	}
-#endif
 
     try
     {


### PR DESCRIPTION
Hello Ryan, 

bcalm 2.2.3 does not disply version info when built from release archive.
commit 9b0f4a0f0d8cc7f78951c131819629cfb47f0165 does not fix the problem, as there is no SHA retrieved on this circumstances, so GIT_SHA1 is undefined so 
all code in `#ifdef GIT_SHA1` is ignored

attached is a change that allows to have the version (as from VERSION file content) displayed in all circumstances, and if built from a git tree it display the commit info.

see
built from release archive
```
[gensoft@f450283090fa bcalm-2.2.3]$ /opt/gensoft/exe/bcalm/2.2.3/bin/bcalm  -version 
BCALM 2, version v2.2.3
Using gatb-core version 1.4.1
```

built from git tree:
```
[gensoft@f450283090fa build]$ ./bcalm -version
BCALM 2, version v2.2.3, git commit c7bfb0d
Using gatb-core version 1.4.1
```

regards 

Eric
